### PR TITLE
Fix emission index typo

### DIFF
--- a/FOORT/src/DiagnosticsEmission.cpp
+++ b/FOORT/src/DiagnosticsEmission.cpp
@@ -129,7 +129,7 @@ OneIndex GeneralCircularRadialFluid::GetFourVelocityd(const Point &p) const
 			for (int j = 0; j < dimension; ++j)
 			{
 				u_up_circ[i] += g_uu[i][j] * p_down_circ[j];
-				u_up_rad[j] += g_uu[i][j] * p_down_rad[j];
+				u_up_rad[i] += g_uu[i][j] * p_down_rad[j];
 			}
 		}
 


### PR DESCRIPTION
This index typo caused a bug when adding radial components to the fluid velocity. It caused unphysical emission in the image, as described in [this issue](https://github.com/SeppeStaelens/FOORT/issues/4). This should be fixed now.